### PR TITLE
Efficient set state

### DIFF
--- a/src/chat-app-frontend/src/App.tsx
+++ b/src/chat-app-frontend/src/App.tsx
@@ -23,7 +23,7 @@ class App extends Component<{}, MyAppState> {
 	constructor(props: any) {
 		super(props);
 
-		this.state = {...INITIAL_APP_STATE};
+		this.state = INITIAL_APP_STATE;
 	}
 
 	onDisconnect = () => {

--- a/src/chat-app-frontend/src/Components/WebSocketChat.tsx
+++ b/src/chat-app-frontend/src/Components/WebSocketChat.tsx
@@ -31,12 +31,12 @@ export class WebSocketChat extends Component<WebSocketWrapperProps, WebSocketWra
 		
 		this.state.websocket.onmessage = (event) => this.setState((previousState) => {
 			console.log(`Received message: ${event.data}`);
-			//! This is a terrible inefficient way to setState because it copies the entire message history (plus all other properties of state) every time a new message comes in.
-			// TODO figure out a more efficient way to do this setState.
-			let newState = {...previousState};
+			let newMsgHistory = previousState.receivedMessageHistory;
 			const parsedMsg = JSON.parse(event.data) as IFromServerChatMessage;
-			newState.receivedMessageHistory.push(parsedMsg);
-			return newState;
+			newMsgHistory.push(parsedMsg);
+			return {
+				receivedMessageHistory: newMsgHistory
+			};
 		});
 
 		this.state.websocket.onopen = () => {
@@ -44,7 +44,7 @@ export class WebSocketChat extends Component<WebSocketWrapperProps, WebSocketWra
 				"clientId": this.props.clientId,
 				"messageType": "clientIntro",
 				"previousMessageId": 0
-			}
+			};
 			const testMessageString: string = JSON.stringify(introMessage);
 			this.state.websocket.send(testMessageString);
 			console.log(`Sent message: ${testMessageString}`);


### PR DESCRIPTION
Made the setState call in the `WebSocketChat` component more efficient by following React best practices.

When you call `this.setState({ stateVariableA: 'new value' });`, React automatically does a shallow merge between the state object you return and the existing state, so you don't have to manage that yourself.

Fixes issue #7 
